### PR TITLE
Add timeout before executing tasks

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -8,7 +8,7 @@ const client = new Discord.Client()
 client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   client.channels.forEach(c => log.info('Found channel ' + c.name))
-  tasks(client)
+  setTimeout(tasks, 5000, client)
 })
 
 client.on('message', message => {


### PR DESCRIPTION
Discord.js takes a while to startup on larger servers, even after the client reports it is ready. This tells the bot to wait before trying to access things, while discord becomes 'ready'