### PR TITLE
Update embeds instead of recreating them

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,3 +1,4 @@
+const Discord = require('discord.js')
 const config = require('./config')
 const { parseBuildId } = require('./parser')
 const { isApprover } = require('./security')
@@ -47,18 +48,18 @@ async function scanReactions (client) {
   const filteredApprovalMessages = approvalMessages.filter(m => m.embeds.length > 0)
   const filteredSubmissionMessages = submissionMessages.filter(m => m.embeds.length > 0 && m.reactions.size > 0)
 
-  return filteredSubmissionMessages.map(async message => {
+  return Promise.all(filteredSubmissionMessages.map(async message => {
     const yesReactions = await countReactions(message, config.yesReaction)
     const noReactions = await countReactions(message, config.noReaction)
 
     if (yesReactions > noReactions && yesReactions >= config.reactionLimit) {
       const similarMessage = findSimilarMessage(message, filteredApprovalMessages)
       const newMessage = {
-        embed: message.embeds[0]
+        embed: new Discord.RichEmbed(message.embeds[0])
       }
 
       if (similarMessage) {
-        return similarMessage.delete().then(() => approvalChannel.send(newMessage)).then(() => message.delete())
+        return similarMessage.edit(newMessage.embed).then(() => message.delete())
       } else {
         return approvalChannel.send(newMessage).then(() => message.delete())
       }
@@ -67,7 +68,7 @@ async function scanReactions (client) {
     }
 
     return null
-  }).filter(m => m != null)
+  }))
 }
 
 module.exports = (client) => {


### PR DESCRIPTION
After build update submission, instead of deleting the message and
recreating it, simply update embed.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>